### PR TITLE
cosmetic changes to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 ### This base container is not aimed at public consumption. It exists to serve as a single endpoint for LinuxServer.io containers and is based upon [Phusion](https://github.com/phusion/baseimage-docker).
 
 If you want to comment\contribute to our work, feel free to join us at out irc channel:
-[IRC](http://www.linuxserver.io/index.php/irc/) on freenode at `#linuxserver.io` or visit our website at [http://linuxserver.io](http://linuxserver.io)
+[IRC](https://www.linuxserver.io/index.php/irc/) on freenode at `#linuxserver.io` or visit our website at [https://linuxserver.io](https://linuxserver.io)


### PR DESCRIPTION
because of some bug in dockerhub, only https addresses are recognised as links.

this leads to gaps in the blurb
