### PR TITLE
remove update of baseimage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM phusion/baseimage:0.9.17
 ENV DEBIAN_FRONTEND="noninteractive" HOME="/root" TERM="screen" 
 RUN useradd -u 911 -U -s /bin/false abc && usermod -G users abc && mkdir -p /app /config /defaults
 ADD sources.list /etc/apt/sources.list
-RUN apt-get update && apt-get upgrade -y -o Dpkg::Options::="--force-confold" && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+#RUN apt-get update && apt-get upgrade -y -o Dpkg::Options::="--force-confold" && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 ADD 10_add_user_abc.sh /etc/my_init.d/10_add_user_abc.sh 
 ADD 20_apt_update.sh /etc/my_init.d/20_apt_update.sh
 RUN chmod +x /etc/my_init.d/10_add_user_abc.sh /etc/my_init.d/20_apt_update.sh


### PR DESCRIPTION
something in this line is causing layer issues resulting in any container trying to pull this image gives this error.

Error pulling image (latest) from docker.io/linuxserver/baseimage, Driver aufs failed to create image rootfs ed3f43ffe5bc8cccedafec7a1a5c6b9eb2e2bdd842f8363da2202ca45f4cc64d: open /var/lib/docker/aufs/layers/fc06acda5256d91654f71bad33e4bba513128b79c4b8179b1d88e86696ce664c: no such file or directory

some cache error....
