### PR TITLE
Pull latest release tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM phusion/baseimage:0.9.18
 ENV DEBIAN_FRONTEND="noninteractive" HOME="/root" TERM="xterm"
-ENV APT_SELECT_URL="https://github.com/jblakeman/apt-select/archive/dc1a1ae133bf849e984d0804372f1eb6a3e666cd.tar.gz"
 COPY sources.list /etc/apt/sources.list
 COPY *.sh /etc/my_init.d/
 RUN useradd -u 911 -U -d /config -s /bin/false abc && \
       usermod -G users abc && \
       mkdir -p /app/aptselect /config /defaults && \
-      curl -L $APT_SELECT_URL | tar xvz -C /app/aptselect --strip-components=1 && \
+      LATEST_TAG=$(curl -sX GET "https://api.github.com/repos/jblakeman/apt-select/releases/latest" | awk '/tag_name/{print $4;exit}' FS='[""]')
+      curl -L https://github.com/jblakeman/apt-select/archive/${LATEST_TAG}.tar.gz | tar xvz -C /app/aptselect --strip-components=1 && \
       apt-get update && \
       apt-get install -y python3-bs4 && \
       apt-get upgrade -y -o Dpkg::Options::="--force-confold" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY *.sh /etc/my_init.d/
 RUN useradd -u 911 -U -d /config -s /bin/false abc && \
       usermod -G users abc && \
       mkdir -p /app/aptselect /config /defaults && \
-      LATEST_TAG=$(curl -sX GET "https://api.github.com/repos/jblakeman/apt-select/releases/latest" | awk '/tag_name/{print $4;exit}' FS='[""]')
+      LATEST_TAG=$(curl -sX GET "https://api.github.com/repos/jblakeman/apt-select/releases/latest" | awk '/tag_name/{print $4;exit}' FS='[""]') && \
       curl -L https://github.com/jblakeman/apt-select/archive/${LATEST_TAG}.tar.gz | tar xvz -C /app/aptselect --strip-components=1 && \
       apt-get update && \
       apt-get install -y python3-bs4 && \


### PR DESCRIPTION
Pull the latest release tag of apt-select.

fulfils not pulling from master, but doesn't require user intervention.
