### PR TITLE
Baseimage2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,4 @@ useradd -u 911 -U -d /config -s /bin/false abc && \
 usermod -G users abc && \
 curl -L https://github.com/just-containers/s6-overlay/releases/download/v1.17.2.0/s6-overlay-amd64.tar.gz | tar xvz -C / && \
 mkdir -p /usr/local/bin/aptselect.d && curl -L https://github.com/jblakeman/apt-select/archive/v0.1.1.tar.gz | tar xvz -C /usr/local/bin/aptselect.d --strip-components=1 && \
-ln -s /usr/local/bin/aptselect.d/apt-select.py /usr/local/bin/apt-select && \
 apt-get clean && rm -rfv /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/root/etc/cont-init.d/20-aptupdate
+++ b/root/etc/cont-init.d/20-aptupdate
@@ -8,7 +8,7 @@
 # run apt-select script to find fastest up to date mirror
 cd /tmp || exit
 echo "Generating sources.list"
-apt-select -t 3 -m up-to-date
+python /usr/local/bin/aptselect.d/apt-select.py -t 3 -m up-to-date
 mv /tmp/sources.list /etc/apt/sources.list
 
 # check for and install any updates


### PR DESCRIPTION
apt-select is a python app
it won't work unless you call it with python and with the full path.
